### PR TITLE
Fix reachability API constant

### DIFF
--- a/src/bloombee/constants.py
+++ b/src/bloombee/constants.py
@@ -13,6 +13,7 @@ PUBLIC_INITIAL_PEERS = [
 ]
 
 # The reachability API is currently used only when connecting to the public swarm
-REACHABILITY_API_URL = "https://github.com/HaibaraAiChan/BloomBee.git"
+# Use BloomBee's health endpoint to verify that a peer is reachable
+REACHABILITY_API_URL = "https://health.bloombee.dev"
 
 DTYPE_MAP = dict(bfloat16=torch.bfloat16, float16=torch.float16, float32=torch.float32, auto="auto")


### PR DESCRIPTION
## Summary
- fix the URL used for reachability checks to point at the health endpoint

## Testing
- `pytest tests/test_dtype.py::test_block_dtype -vv --maxfail=1` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_683f655a320c8327a43bfd426a1f578c