### PR TITLE
Optimize downstream decode push path

### DIFF
--- a/src/bloombee/client/config.py
+++ b/src/bloombee/client/config.py
@@ -8,6 +8,12 @@ from bloombee.constants import PUBLIC_INITIAL_PEERS
 
 _max_retries = os.getenv("BLOOMBEE_MAX_RETRIES")
 DEFAULT_MAX_RETRIES = int(_max_retries) if isinstance(_max_retries, str) else None
+_push_only_downstream_decode = os.getenv("BLOOMBEE_PUSH_ONLY_DOWNSTREAM_DECODE")
+DEFAULT_PUSH_ONLY_DOWNSTREAM_DECODE = (
+    _push_only_downstream_decode.strip().lower() not in {"0", "false", "no", "off"}
+    if isinstance(_push_only_downstream_decode, str)
+    else True
+)
 
 
 @dataclasses.dataclass
@@ -20,6 +26,7 @@ class ClientConfig:
     allowed_servers: Optional[Sequence[Union[PeerID, str]]] = None  # if defined, send requests only to these servers
     blocked_servers: Optional[Sequence[Union[PeerID, str]]] = None  # if defined, do not use these servers
     use_server_to_server: bool = True  # Use direct server-to-server communication
+    push_only_downstream_decode: bool = DEFAULT_PUSH_ONLY_DOWNSTREAM_DECODE  # downstream decode waits for upstream rpc_push after warmup
 
     connect_timeout: float = 5  # timeout for opening a connection
     request_timeout: float = 3 * 60  # timeout for forward/backward/inference requests

--- a/src/bloombee/client/inference_session.py
+++ b/src/bloombee/client/inference_session.py
@@ -176,119 +176,132 @@ class _ServerInferenceSession:
             _infer_batch_dim(tree_attention_mask),
             1,
         )
-
-        # serialize inputs and put them into the queue
-        
-        input_tensors, args_structure = pack_args_kwargs(
-            inputs, 
-            normalize_arg(keep_indices),
-            normalize_arg(torch.tensor(1 if need_pruning else 0)),
-            normalize_arg(tree_attention_mask),
-            normalize_arg(kv_cache_position_ids),
-            normalize_arg(draft_tokens),
-            normalize_arg(prefill_length),
-            normalize_arg(torch.tensor(1 if is_spec_dec else 0)),
-            prompts,
-            hypo_ids,
+        push_only_decode = (
+            self.config.use_server_to_server
+            and getattr(self.config, "push_only_downstream_decode", False)
+            and self.stepped
+            and self.span.start > 0
+            and not is_spec_dec
         )
+        transport_phase = "push_only_decode" if push_only_decode else (
+            "spec_decode" if is_spec_dec else ("prefill" if not self.stepped else "decode")
+        )
+
         client_inference_logs_enabled = is_log_channel_enabled("client_inference_logs")
         if client_inference_logs_enabled:
             logger.info(f"_ServerInferenceSession  step id {step_id}")
-        request_metadata = dict(session_id=self.session_id, step_id=step_id)
-        if not self.stepped:
-            request_metadata.update(self.session_metadata)
-        # Explicitly expose speculative-decoding mode in metadata so the server
-        # can make safe KV allocation decisions before first step processing.
-        request_metadata["is_spec_dec"] = 1 if is_spec_dec else 0
-        request_metadata["full_batch_size"] = int(logical_full_batch_size)
-        request_metadata["micro_batch_size"] = int(inputs.shape[0]) if inputs.ndim >= 1 else 1
-        if is_spec_dec:
-            request_metadata["start_from_position"] = self._position + n_input_tokens
-        else:
-            if self._position is not None:
-                request_metadata["start_from_position"] = self._position
-        # Enable server-to-server communication to trigger CROSS_GPU_TRANSFER
-        # Speculative decoding keeps strict full-batch semantics; avoid cross-stage push.
-        if self.config.use_server_to_server:
-            next_servers = self._collect_next_servers()
-            if next_servers:
-                request_metadata["next_servers"] = next_servers
+        if push_only_decode and client_inference_logs_enabled:
+            logger.info(
+                f"[NETWORK_TX] PUSH_ONLY_WAIT | step_id={step_id} | "
+                f"blocks={self.span.start}:{self.span.end} | session_id={self.session_id}"
+            )
 
-        request_metadata["args_structure"] = args_structure
-
-        # TODO: make possible to use different compression method for different tensors
-        server_side_inference_schema, kwargs_schema = self.rpc_info["inference_schema"]
-        compression = server_side_inference_schema[0].compression
-        inference_schema = tuple(BatchTensorDescriptor.from_tensor(arg, compression) for arg in input_tensors)
-        transport_phase = "spec_decode" if is_spec_dec else ("prefill" if not self.stepped else "decode")
-        tensor_debug_names = (
-            "hidden_states",
-            "keep_indices",
-            "need_pruning",
-            "prompts",
-            "hypo_ids",
-            "tree_attention_mask",
-            "kv_cache_position_ids",
-            "draft_tokens",
-            "prefill_length",
-            "is_spec_dec",
-        )
-
-        # TODO: create more explicit way to check servers schema and client's structure
-        # assert len(input_tensors) >= len(
-        #     server_side_inference_schema
-        # ), "Hidden_state, prompts and hypo_ids tensors are necessary for an inference step"
+        total_send_bytes = 0
+        serialize_time_ms = 0.0
 
         with transport_profile_scope() as transport_profile:
-            # [NETWORK_TIMING] Measure serialization time
-            serialize_start = time.perf_counter()
-
-            # Serialize and send data (debug output removed for performance)
-            # Fix for bus error in cross-machine setups: ensure tensors are contiguous before serialization
-            serialized_tensors = [
-                serialize_torch_tensor(
-                    tensor.contiguous().to(proto.dtype) if not tensor.is_contiguous() else tensor.to(proto.dtype),
-                    proto.compression,
-                    debug_context={
-                        "phase": transport_phase,
-                        "tensor_name": tensor_debug_names[idx] if idx < len(tensor_debug_names) else f"arg_{idx}",
-                        "source": "client",
-                        "channel": "rpc_inference",
-                        "blocks": f"{self.span.start}:{self.span.end}",
-                        "batch": int(logical_full_batch_size),
-                    },
+            if not push_only_decode:
+                input_tensors, args_structure = pack_args_kwargs(
+                    inputs,
+                    normalize_arg(keep_indices),
+                    normalize_arg(torch.tensor(1 if need_pruning else 0)),
+                    normalize_arg(tree_attention_mask),
+                    normalize_arg(kv_cache_position_ids),
+                    normalize_arg(draft_tokens),
+                    normalize_arg(prefill_length),
+                    normalize_arg(torch.tensor(1 if is_spec_dec else 0)),
+                    prompts,
+                    hypo_ids,
                 )
-                for idx, (tensor, proto) in enumerate(zip(input_tensors, inference_schema))
-            ]
-            serialized_metadata = MSGPackSerializer.dumps(request_metadata)
+                request_metadata = dict(session_id=self.session_id, step_id=step_id)
+                if not self.stepped:
+                    request_metadata.update(self.session_metadata)
+                # Explicitly expose speculative-decoding mode in metadata so the server
+                # can make safe KV allocation decisions before first step processing.
+                request_metadata["is_spec_dec"] = 1 if is_spec_dec else 0
+                request_metadata["full_batch_size"] = int(logical_full_batch_size)
+                request_metadata["micro_batch_size"] = int(inputs.shape[0]) if inputs.ndim >= 1 else 1
+                if is_spec_dec:
+                    request_metadata["start_from_position"] = self._position + n_input_tokens
+                elif self._position is not None:
+                    request_metadata["start_from_position"] = self._position
+                # Enable server-to-server communication to trigger CROSS_GPU_TRANSFER
+                # Speculative decoding keeps strict full-batch semantics; avoid cross-stage push.
+                if self.config.use_server_to_server:
+                    next_servers = self._collect_next_servers()
+                    if next_servers:
+                        request_metadata["next_servers"] = next_servers
 
-            serialize_end = time.perf_counter()
-            serialize_time_ms = (serialize_end - serialize_start) * 1000
+                request_metadata["args_structure"] = args_structure
 
-            # [NETWORK_TIMING] Measure serialized data size
-            total_tensor_bytes = sum(len(t.buffer) for t in serialized_tensors)
-            metadata_bytes = len(serialized_metadata)
-            total_send_bytes = total_tensor_bytes + metadata_bytes
+                # TODO: make possible to use different compression method for different tensors
+                server_side_inference_schema, kwargs_schema = self.rpc_info["inference_schema"]
+                compression = server_side_inference_schema[0].compression
+                inference_schema = tuple(BatchTensorDescriptor.from_tensor(arg, compression) for arg in input_tensors)
+                tensor_debug_names = (
+                    "hidden_states",
+                    "keep_indices",
+                    "need_pruning",
+                    "prompts",
+                    "hypo_ids",
+                    "tree_attention_mask",
+                    "kv_cache_position_ids",
+                    "draft_tokens",
+                    "prefill_length",
+                    "is_spec_dec",
+                )
 
-            if client_inference_logs_enabled:
-                logger.info(f"[NETWORK_TX] SEND_START | step_id={step_id} | "
-                           f"tensor_size={total_tensor_bytes/1024:.2f}KB | "
-                           f"metadata_size={metadata_bytes}B | "
-                           f"total={total_send_bytes/1024:.2f}KB | "
-                           f"serialize_time={serialize_time_ms:.2f}ms")
+                # [NETWORK_TIMING] Measure serialization time
+                serialize_start = time.perf_counter()
+
+                # Serialize and send data (debug output removed for performance)
+                # Fix for bus error in cross-machine setups: ensure tensors are contiguous before serialization
+                serialized_tensors = [
+                    serialize_torch_tensor(
+                        tensor.contiguous().to(proto.dtype) if not tensor.is_contiguous() else tensor.to(proto.dtype),
+                        proto.compression,
+                        debug_context={
+                            "phase": transport_phase,
+                            "tensor_name": tensor_debug_names[idx] if idx < len(tensor_debug_names) else f"arg_{idx}",
+                            "source": "client",
+                            "channel": "rpc_inference",
+                            "blocks": f"{self.span.start}:{self.span.end}",
+                            "batch": int(logical_full_batch_size),
+                        },
+                    )
+                    for idx, (tensor, proto) in enumerate(zip(input_tensors, inference_schema))
+                ]
+                serialized_metadata = MSGPackSerializer.dumps(request_metadata)
+
+                serialize_end = time.perf_counter()
+                serialize_time_ms = (serialize_end - serialize_start) * 1000
+
+                # [NETWORK_TIMING] Measure serialized data size
+                total_tensor_bytes = sum(len(t.buffer) for t in serialized_tensors)
+                metadata_bytes = len(serialized_metadata)
+                total_send_bytes = total_tensor_bytes + metadata_bytes
+
+                if client_inference_logs_enabled:
+                    logger.info(f"[NETWORK_TX] SEND_START | step_id={step_id} | "
+                               f"tensor_size={total_tensor_bytes/1024:.2f}KB | "
+                               f"metadata_size={metadata_bytes}B | "
+                               f"total={total_send_bytes/1024:.2f}KB | "
+                               f"serialize_time={serialize_time_ms:.2f}ms")
 
             # [NETWORK_TIMING] Measure network round-trip time
             network_start = time.perf_counter()
-
-            outputs_serialized = RemoteExpertWorker.run_coroutine(
-                self._step(
-                    runtime_pb2.ExpertRequest(
-                        uid=self.uid,
-                        tensors=serialized_tensors,
-                        metadata=serialized_metadata,
+            if push_only_decode:
+                outputs_serialized = RemoteExpertWorker.run_coroutine(self._await_pushed_step())
+            else:
+                outputs_serialized = RemoteExpertWorker.run_coroutine(
+                    self._step(
+                        runtime_pb2.ExpertRequest(
+                            uid=self.uid,
+                            tensors=serialized_tensors,
+                            metadata=serialized_metadata,
+                        )
                     )
                 )
-            )
 
             network_end = time.perf_counter()
             network_rtt_ms = (network_end - network_start) * 1000
@@ -422,6 +435,10 @@ class _ServerInferenceSession:
         """Inference step on serialized data. This code is meant to be run inside RemoteExpertWorker"""
         await self._inputs_queue.put(inputs_serialized)
         self.stepped = True
+        return await asyncio.wait_for(anext(self._outputs_stream), self.config.request_timeout)
+
+    async def _await_pushed_step(self) -> runtime_pb2.ExpertResponse:
+        """Wait for the next pushed decode output on an already-open downstream session."""
         return await asyncio.wait_for(anext(self._outputs_stream), self.config.request_timeout)
 
     def close(self):

--- a/src/bloombee/server/handler.py
+++ b/src/bloombee/server/handler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import multiprocessing as mp
+import os
 import sys
 from collections import deque
 from enum import Enum
@@ -59,6 +60,17 @@ from bloombee.utils.microbatch_schema import (
 )
 
 logger = get_logger(__name__)
+
+_s2s_output_compression_name = os.getenv("BLOOMBEE_S2S_OUTPUT_COMPRESSION", "").strip().upper()
+_s2s_output_compression = None
+if _s2s_output_compression_name:
+    try:
+        _s2s_output_compression = getattr(runtime_pb2.CompressionType, _s2s_output_compression_name)
+    except AttributeError:
+        logger.warning(
+            "Unknown BLOOMBEE_S2S_OUTPUT_COMPRESSION=%r, falling back to default rpc_push compression",
+            _s2s_output_compression_name,
+        )
 
 if TYPE_CHECKING:
     from bloombee.server.speculative_pruner.pruner_manager import SpeculativePrunerManager
@@ -2766,7 +2778,7 @@ class TransformerConnectionHandler(ConnectionHandler):
             with transport_profile_scope() as push_transport_profile:
                 serialized_hidden = serialize_torch_tensor(
                     mb_hidden.to(outputs_schema[0].dtype),
-                    outputs_schema[0].compression,
+                    _s2s_output_compression if _s2s_output_compression is not None else outputs_schema[0].compression,
                     allow_inplace=True,
                     debug_context={
                         "phase": transport_phase,


### PR DESCRIPTION
PR Title
  Optimize downstream decode push path and add optional s2s output compression hook

  PR Description

  ## Summary

  This PR reduces downstream decode-path contention in server-to-server inference and adds an opt-in hook for
  stage-to-stage output compression experiments.

  The main issue was that downstream stages could keep consuming client-side decode requests even after the session
  was warm and upstream `rpc_push` was already available. That caused unnecessary competition between the client
  stream and the push queue on the downstream server.

  ## Changes

  ### 1. Add push-only downstream decode mode
  - Add `push_only_downstream_decode` to client config.
  - Default it from `BLOOMBEE_PUSH_ONLY_DOWNSTREAM_DECODE` and keep the default enabled.

  ### 2. Reuse the already-open downstream inference stream during decode
  - In `_ServerInferenceSession.step()`, when:
    - server-to-server mode is enabled,
    - the session is already stepped,
    - the span is downstream (`span.start > 0`),
    - and the request is not speculative decode,
    the client no longer serializes and sends a fresh downstream decode request.
  - Instead, it waits for the next pushed output from the already-open stream.

  ### 3. Add an optional server-to-server output compression override
  - Add `BLOOMBEE_S2S_OUTPUT_COMPRESSION` as an opt-in override for the hidden-state tensor serialized in
  `rpc_push`.
  - This does not change default behavior unless the env var is explicitly set.
  - Intended for WAN / relay / NAT experiments where `T_NIC->NIC` dominates.

  ## Why this helps

  The previous path allowed downstream decode to compete between:
  - the client `rpc_inference` stream, and
  - upstream `rpc_push`

  That increased receiver-side processing and inflated sender-observed `push_e2e` latency.

  The new decode path keeps downstream steady-state decode aligned with upstream push delivery and preserves the
  already-open session stream for receiving pushed outputs.


  ## Notes

  - This PR does not change the default server `num_handlers`.
  - This PR does not yet replace Hivemind unary protobuf `rpc_push` with a binary stream path.
  - The new s2s compression hook is intentionally off by default.

  ## Next steps

  1. Benchmark `BLOOMBEE_S2S_OUTPUT_COMPRESSION=BLOCKWISE_8BIT` in real cross-machine relay / NAT environments.
  2. Measure the impact on:
     - `T_NIC->NIC`
     - sender-observed `push_e2e`
     - effective throughput
     - output quality / numerical stability
  3. If WAN overhead remains dominant, prototype replacing unary protobuf `rpc_push` with a long-lived Hivemind
  binary stream path for stage-to-stage transfers.
  