### PR TITLE
Fix S2S telemetry initialization after extraction

### DIFF
--- a/src/bloombee/server/s2s_flow.py
+++ b/src/bloombee/server/s2s_flow.py
@@ -18,6 +18,7 @@ from typing import Deque, Optional
 from bloombee.utils.microbatch_config import MBPIPE_LOG_PREFIX
 
 
+@dataclass
 class S2SLinkTelemetry:
     """
     Rolling transport telemetry for one server-to-server link.
@@ -67,6 +68,7 @@ class S2SLinkTelemetry:
         self.jitter_ms_window.append(float(jitter_ms))
         self.raw_latency_ms_window.append(float(raw_latency_ms))
         return jitter_ms
+
 
 class AdaptivePushConcurrency:
     """
@@ -157,7 +159,11 @@ class AdaptivePushConcurrency:
                     reason = "send_failures"
                 # If local wait is non-trivial while network send remains moderate,
                 # increase concurrency to reduce sender-side queue pressure.
-                elif self._ewma_wait_ms > 8.0 and self._ewma_send_ms < 220.0 and self._in_flight >= max(1, self._limit - 1):
+                elif (
+                    self._ewma_wait_ms > 8.0
+                    and self._ewma_send_ms < 220.0
+                    and self._in_flight >= max(1, self._limit - 1)
+                ):
                     self._limit = min(self._max_limit, self._limit + 1)
                     reason = "queue_pressure"
                 # If network send slows down a lot, decrease concurrency to avoid congestion collapse.
@@ -184,5 +190,3 @@ class AdaptivePushConcurrency:
                 f"{old_limit}->{new_limit} reason={reason} "
                 f"ewma_wait={ewma_wait_ms:.1f}ms ewma_send={ewma_send_ms:.1f}ms in_flight={in_flight}"
             )
-
-

--- a/tests/test_s2s_flow.py
+++ b/tests/test_s2s_flow.py
@@ -1,0 +1,34 @@
+from bloombee.server.s2s_flow import S2SLinkTelemetry
+
+
+def test_s2s_link_telemetry_initializes_and_records_samples():
+    telemetry = S2SLinkTelemetry(label="decode:0:8->8:16", window_size=2)
+
+    assert telemetry.label == "decode:0:8->8:16"
+    assert telemetry.latency_ms_window.maxlen == 2
+
+    assert (
+        telemetry.record(
+            latency_ms=10.0,
+            raw_latency_ms=12.0,
+            bandwidth_mbps=100.0,
+            total_bytes=1024,
+            clock_sync_ok=True,
+        )
+        == 0.0
+    )
+    assert (
+        telemetry.record(
+            latency_ms=13.5,
+            raw_latency_ms=15.0,
+            bandwidth_mbps=80.0,
+            total_bytes=2048,
+            clock_sync_ok=False,
+        )
+        == 3.5
+    )
+
+    assert telemetry.samples == 2
+    assert telemetry.total_bytes == 3072
+    assert telemetry.clock_sync_samples == 1
+    assert list(telemetry.latency_ms_window) == [10.0, 13.5]


### PR DESCRIPTION
## Summary

Fix cross-server link telemetry initialization by restoring the `@dataclass` decorator that was lost when `S2SLinkTelemetry` moved from `handler.py` to `s2s_flow.py`.

## Bug and root cause

`TransformerConnectionHandler._record_s2s_network_sample()` constructs telemetry with `S2SLinkTelemetry(label=..., window_size=...)` on the first sample for each link. The extracted class only retained dataclass field declarations and `__post_init__`; without `@dataclass`, Python supplied neither the generated constructor nor the `__post_init__` call. The first S2S network sample therefore raised:

```text
TypeError: S2SLinkTelemetry() takes no arguments
```

The pre-extraction implementation in `handler.py` had the decorator.

## Fix

- Restore `@dataclass` on `S2SLinkTelemetry`.
- Add a regression test covering construction, deque initialization, jitter calculation, byte/sample accumulation, and clock-sync counting.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation update
- [ ] CI / tooling change
- [ ] Other

## Evidence and testing

Pre-fix isolated reproduction: constructor raises the `TypeError` above.

Post-fix checks:

- Isolated execution of the telemetry constructor and two `record()` calls: PASS
- `python3 -m compileall -q src/bloombee/server/s2s_flow.py tests/test_s2s_flow.py`
- `uvx ruff check src/bloombee/server/s2s_flow.py tests/test_s2s_flow.py --output-format concise`
- `uvx --from black==22.3.0 black --check src/bloombee/server/s2s_flow.py tests/test_s2s_flow.py`
- `uvx --from isort==5.10.1 isort --check-only src/bloombee/server/s2s_flow.py tests/test_s2s_flow.py`
- `git diff --check`

The full pytest environment was not available locally because this worktree has no PyTorch/Hivemind installation; the added test is intended for the repository CI environment.

## Checklist

- [x] Code is formatted with `black` and `isort`
- [x] No unrelated files are included in this PR
- [x] Relevant documentation is unchanged because this restores intended existing behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small bug fix restoring intended dataclass behavior for observability; no auth, data, or pipeline control logic changes beyond fixing broken telemetry initialization.
> 
> **Overview**
> Restores **`@dataclass`** on **`S2SLinkTelemetry`** in `s2s_flow.py` so `S2SLinkTelemetry(label=..., window_size=...)` works again when `handler.py` lazily creates per-link telemetry on the first S2S network sample. Without the decorator, construction raised **`TypeError: S2SLinkTelemetry() takes no arguments`** and **`__post_init__`** never ran to size the sliding deques.
> 
> Adds **`tests/test_s2s_flow.py`** as a regression test for construction, deque windows, jitter on the second sample, byte/sample counters, and clock-sync counting. The diff also includes minor whitespace/formatting in **`AdaptivePushConcurrency`** (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e352ab835d6f41ece1f435c9fad3d2b6a8cb689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->