### PR TITLE
Honor --revision when loading Hugging Face block weights

### DIFF
--- a/src/bloombee/server/from_pretrained.py
+++ b/src/bloombee/server/from_pretrained.py
@@ -72,7 +72,7 @@ def load_pretrained_block(
     tensor_parallel_devices: Optional[Sequence[torch.device]] = None,
 ) -> nn.Module:
     if config is None:
-        config = AutoDistributedConfig.from_pretrained(model_name, use_auth_token=token)
+        config = AutoDistributedConfig.from_pretrained(model_name, use_auth_token=token, revision=revision)
     if cache_dir is None:
         cache_dir = DEFAULT_CACHE_DIR
 
@@ -123,8 +123,15 @@ def load_pretrained_block(
         # For HF-based models: create block normally (weights on CPU) then load state dict
         block = get_model_block(config, env, policy, weight_home, path, layer_idx=block_index)
         block = _load_hf_block_weights(
-            block, model_name, block_index, config,
-            token=token, cache_dir=cache_dir, max_disk_space=max_disk_space, torch_dtype=torch_dtype,
+            block,
+            model_name,
+            block_index,
+            config,
+            revision=revision,
+            token=token,
+            cache_dir=cache_dir,
+            max_disk_space=max_disk_space,
+            torch_dtype=torch_dtype,
         )
     else:
         # For FlexGen-based models (Llama): weights are managed by FlexGen at runtime.
@@ -151,6 +158,7 @@ def _load_hf_block_weights(
     block_index: int,
     config: PretrainedConfig,
     *,
+    revision: Optional[str],
     token: Optional[Union[str, bool]],
     cache_dir: str,
     max_disk_space: Optional[int],
@@ -162,6 +170,7 @@ def _load_hf_block_weights(
     state_dict = _load_state_dict_from_repo(
         model_name,
         block_prefix,
+        revision=revision,
         token=token,
         cache_dir=cache_dir,
         max_disk_space=max_disk_space,
@@ -188,7 +197,13 @@ def _load_state_dict_from_repo(
 
     index_file = _find_index_file(model_name, revision=revision, token=token, cache_dir=cache_dir)
     if index_file.endswith(".index.json"):  # Sharded model
-        path = get_file_from_repo(model_name, filename=index_file, use_auth_token=token, cache_dir=cache_dir)
+        path = get_file_from_repo(
+            model_name,
+            filename=index_file,
+            revision=revision,
+            use_auth_token=token,
+            cache_dir=cache_dir,
+        )
         if path is None:
             # _find_index_file() told that a file exists but we can't get it (e.g., it just disappeared)
             raise ValueError(f"Failed to get file {index_file}")

--- a/tests/test_from_pretrained_revision.py
+++ b/tests/test_from_pretrained_revision.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+
+import torch
+
+from bloombee.server import from_pretrained
+
+
+def test_load_pretrained_block_forwards_revision_to_config_and_weights(monkeypatch):
+    revision = "0123456789abcdef"
+    config_calls = []
+    weight_calls = []
+    config = SimpleNamespace(
+        block_class=from_pretrained.WrappedBloomBlock,
+        block_prefix="transformer.h",
+        model_type="bloom",
+        _name_or_path="test/model",
+    )
+    block = torch.nn.Linear(1, 1)
+
+    def fake_config_from_pretrained(model_name, **kwargs):
+        config_calls.append((model_name, kwargs))
+        return config
+
+    def fake_load_hf_block_weights(*args, **kwargs):
+        weight_calls.append((args, kwargs))
+        return block
+
+    monkeypatch.setattr(
+        from_pretrained.AutoDistributedConfig,
+        "from_pretrained",
+        fake_config_from_pretrained,
+    )
+    monkeypatch.setattr(from_pretrained, "resolve_block_dtype", lambda config, dtype: dtype)
+    monkeypatch.setattr(from_pretrained, "get_model_block", lambda *args, **kwargs: block)
+    monkeypatch.setattr(from_pretrained, "_load_hf_block_weights", fake_load_hf_block_weights)
+
+    result = from_pretrained.load_pretrained_block(
+        "test/model",
+        block_index=3,
+        env=None,
+        policy=None,
+        weight_home=None,
+        path="unused",
+        torch_dtype=torch.float32,
+        revision=revision,
+        token="token",
+        cache_dir="/tmp/cache",
+    )
+
+    assert result is block
+    assert config_calls == [("test/model", {"use_auth_token": "token", "revision": revision})]
+    assert weight_calls[0][1]["revision"] == revision
+
+
+def test_sharded_index_and_weights_use_requested_revision(tmp_path, monkeypatch):
+    revision = "0123456789abcdef"
+    block_prefix = "model.layers.3."
+    index_path = tmp_path / "model.safetensors.index.json"
+    index_path.write_text('{"weight_map": {"model.layers.3.weight": "model-00001-of-00002.safetensors"}}')
+    index_calls = []
+    file_calls = []
+    shard_calls = []
+
+    def fake_find_index_file(model_name, **kwargs):
+        index_calls.append((model_name, kwargs))
+        return index_path.name
+
+    def fake_get_file_from_repo(model_name, **kwargs):
+        file_calls.append((model_name, kwargs))
+        return str(index_path)
+
+    def fake_load_state_dict_file(model_name, filename, **kwargs):
+        shard_calls.append((model_name, filename, kwargs))
+        return {"model.layers.3.weight": torch.ones(1)}
+
+    monkeypatch.setattr(from_pretrained, "_find_index_file", fake_find_index_file)
+    monkeypatch.setattr(from_pretrained, "get_file_from_repo", fake_get_file_from_repo)
+    monkeypatch.setattr(
+        from_pretrained,
+        "_load_state_dict_from_repo_file",
+        fake_load_state_dict_file,
+    )
+
+    state_dict = from_pretrained._load_state_dict_from_repo(
+        "test/model",
+        block_prefix,
+        revision=revision,
+        cache_dir=str(tmp_path),
+    )
+
+    assert set(state_dict) == {"weight"}
+    assert index_calls[0][1]["revision"] == revision
+    assert file_calls[0][1]["revision"] == revision
+    assert shard_calls[0][2]["revision"] == revision


### PR DESCRIPTION
## Summary

Ensure `--revision` selects the same Hugging Face revision for model configuration, sharded weight indexes, and block weight files.

## Bug and root cause

The CLI and `Server` passed `revision` into `load_pretrained_block`, but the Hugging Face block-loading path dropped it before `_load_hf_block_weights`. When `load_pretrained_block` loaded its own config, that lookup also omitted the revision. In addition, the sharded index download called `get_file_from_repo` without the revision.

As a result, a server started with `--revision <commit>` could combine the requested revision config with the repository default branch index/weights, silently serving the wrong checkpoint or failing on config/weight shape mismatches.

## Fix

- Pass `revision` into config loading when no config is supplied.
- Thread `revision` through the Hugging Face block-weight helper.
- Fetch sharded weight indexes from the requested revision.
- Add regression tests for the complete config/index/shard propagation path.

## Evidence and testing

Before the fix, source tracing and the regression mocks show the value is absent from all three calls. After the fix:

- `/tmp/bloombee-bugfix-venv/bin/python -m pytest -q tests/test_from_pretrained_revision.py` — 2 passed
- `python3 -m compileall -q src/bloombee/server/from_pretrained.py tests/test_from_pretrained_revision.py`
- `uvx ruff check tests/test_from_pretrained_revision.py --output-format concise`
- `uvx --from black==22.3.0 black --check tests/test_from_pretrained_revision.py`
- `uvx --from isort==5.10.1 isort --check-only tests/test_from_pretrained_revision.py`
- `git diff --check`

The full editable dependency set cannot resolve on macOS ARM because the repository pins `bitsandbytes==0.46.0`, which has no matching wheel; the targeted test environment installed the remaining runtime dependencies and exercised the production module directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Incorrect revision handling could serve wrong model weights or cause shape mismatches; the fix is narrow to `from_pretrained.py` with targeted tests.
> 
> **Overview**
> Fixes a bug where `--revision` was accepted by `load_pretrained_block` but not applied consistently on the Hugging Face load path, so config, sharded index files, and shard downloads could come from different Hub revisions.
> 
> **`revision` is now threaded through** `AutoDistributedConfig.from_pretrained`, `_load_hf_block_weights`, and `get_file_from_repo` when fetching sharded `*.index.json` files, aligning config and weights with the requested commit/tag/branch.
> 
> Adds regression tests in `tests/test_from_pretrained_revision.py` that assert revision is passed into config load, index lookup, index download, and shard load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05c2ebfa8b3b3e1e5b46d274fb0639ab7c4c9b5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->